### PR TITLE
Add spago configuration, upgrade to purs 0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "pulp build -- --censor-lib --strict",
-    "test": "pulp test"
+    "build": "spago build",
+    "test": "spago test"
   },
   "devDependencies": {
+    "purescript": "^0.15.0",
     "purescript-psa": "^0.7.3",
-    "purescript": "^0.13.0",
-    "pulp": "^13.0.0"
+    "spago": "^0.20.9"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,4 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.2-20220630/packages.dhall sha256:691aff166010760f18ab1f4842ba6184f43747756e00579a050a2a46fa22d014
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,22 @@
+{ name = "bytestrings"
+, dependencies =
+    [ "arrays"
+    , "console"
+    , "effect"
+    , "exceptions"
+    , "foldable-traversable"
+    , "integers"
+    , "leibniz"
+    , "maybe"
+    , "newtype"
+    , "node-buffer"
+    , "partial"
+    , "prelude"
+    , "quickcheck"
+    , "quickcheck-laws"
+    , "quotient"
+    , "unsafe-coerce"
+    ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/src/Data/ByteString.js
+++ b/src/Data/ByteString.js
@@ -1,12 +1,10 @@
-'use strict';
-
-exports.unsafeIndex = function(buffer) {
+export function unsafeIndex (buffer) {
     return function(offset) {
         return buffer[offset];
     };
 };
 
-exports.realGetAtOffset = function(Nothing) {
+export function realGetAtOffset (Nothing) {
     return function(Just) {
         return function(offset) {
             return function(buffer) {
@@ -21,7 +19,7 @@ exports.realGetAtOffset = function(Nothing) {
     };
 };
 
-exports.foldl = function(f) {
+export function foldl (f) {
     return function(z) {
         return function(buf) {
             var r = z;
@@ -34,7 +32,7 @@ exports.foldl = function(f) {
     };
 };
 
-exports.foldr = function(f) {
+export function foldr (f) {
     return function(z) {
         return function(buf) {
             var r = z;


### PR DESCRIPTION
This package needs to be updated to work with purs 0.15 in order to continue to make progress on the 0.15 package sets. It was just as easy to add the spago configuration in the same pass